### PR TITLE
Updated Crucible to Potion Craft v0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 */bin
 */obj
 /externals
+/.vs/potioncraft-crucible/FileContentIndex
+/.vs/potioncraft-crucible/v17
+/.vs/ProjectEvaluation
+/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 */bin
 */obj
 /externals
-/.vs/potioncraft-crucible/FileContentIndex
 /.vs/potioncraft-crucible/v17
+/.vs/potioncraft-crucible/DesignTimeBuild
+/.vs/potioncraft-crucible/project-colors.json
+/.vs/slnx.sqlite
+/.vs/VSWorkspaceState.json
+/.vs/potioncraft-crucible/FileContentIndex
 /.vs/ProjectEvaluation
 /.vs

--- a/Crucible.GameAPI/BackwardsCompatibility/OldIngredientIdConvert.cs
+++ b/Crucible.GameAPI/BackwardsCompatibility/OldIngredientIdConvert.cs
@@ -1,0 +1,54 @@
+﻿// <copyright file="OldIngredientIdConvert.cs" company="RoboPhredDev">
+// This file is part of the Crucible Modding Framework.
+//
+// Crucible is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+// Crucible is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// You should have received a copy of the GNU Lesser General Public License
+// along with Crucible; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+// </copyright>
+
+namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.BackwardsCompatibility
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Provides tools for converting old ingredient ids to new ingredient ids.
+    /// </summary>
+    public static class OldIngredientIdConvert
+    {
+        /// <summary>
+        /// Gets dictionary containing old ingredient ids as keys with new ingredient ids as values.
+        /// </summary>
+        public static Dictionary<string, string> IngredientConvertDict { get; } = new Dictionary<string, string>
+        {
+            { "BloodyRoot", "Bloodthorn" },
+            { "CliffFungus", "Mudshroom" },
+            { "Crystal", "CloudCrystal" },
+            { "DryadMushroom", "DryadsSaddle" },
+            { "EarthCrystal", "EarthPyrite" },
+            { "GreenMushroom", "StinkMushroom" },
+            { "GreyChanterelle", "ShadowChanterelle" },
+            { "IceDragonfruit", "Icefruit" },
+            { "LavaRoot", "Lavaroot" },
+            { "Leaf", "Lifeleaf" },
+            { "LumpyBeet", "DreamBeet" },
+            { "Marshrooms", "Marshroom" },
+            { "RedMushroom", "MadMushroom" },
+            { "Refruit", "HairyBanana" },
+            { "Tangleweeds", "Tangleweed" },
+            { "Thistle", "ThunderThistle" },
+            { "Wierdshroom", "Weirdshroom" },
+        };
+    }
+}

--- a/Crucible.GameAPI/Crucible.GameAPI.csproj
+++ b/Crucible.GameAPI/Crucible.GameAPI.csproj
@@ -21,6 +21,9 @@
     <Reference Include="0Harmony" CopyToPublishDirectory="Never">
       <HintPath>..\externals\0Harmony.dll</HintPath>
     </Reference>
+    <Reference Include="PotionCraft.GamepadNavigation">
+      <HintPath>..\externals\PotionCraft.GamepadNavigation.dll</HintPath>
+    </Reference>
 
     <Reference Include="UnityEngine" CopyToPublishDirectory="Never">
       <HintPath>..\externals\UnityEngine.dll</HintPath>

--- a/Crucible.GameAPI/Crucible.GameAPI.csproj
+++ b/Crucible.GameAPI/Crucible.GameAPI.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="../stylecop.json"/>
+    <AdditionalFiles Include="../stylecop.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Crucible.GameAPI/CrucibleCustomerNpcTemplate.cs
+++ b/Crucible.GameAPI/CrucibleCustomerNpcTemplate.cs
@@ -14,7 +14,6 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
-#if DISABLED_FOR_0_5
 
 namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
 {
@@ -27,6 +26,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
     using global::PotionCraft.Npc.Parts;
     using global::PotionCraft.Npc.Parts.Settings;
     using global::PotionCraft.QuestSystem;
+    using global::PotionCraft.ScriptableObjects;
     using UnityEngine;
 
     /// <summary>
@@ -120,14 +120,14 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
 
             var template = ScriptableObject.CreateInstance<NpcTemplate>();
 
-            template.spawnChance = 1f;
+            //template.spawnChance = 1f;
 
             var quest = ScriptableObject.CreateInstance<Quest>();
             quest.name = name;
             quest.karmaReward = 0;
             quest.desiredEffects = new PotionEffect[0];
 
-            var copyFrom = NpcTemplate.allNpcTemplates.Find(x => x.name == "HerbalistNpc 1");
+            var copyFrom = NpcTemplate.allNpcTemplates.templates.Find(x => x.name == "HerbalistNpc 1");
             if (copyFrom == null)
             {
                 throw new Exception("Could not load dummy template to copy from.");
@@ -162,7 +162,6 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             template.baseParts = new NonAppearancePart[] { quest, prefab, gender, dialogueData };
 
             template.name = name;
-            template.groupsOfContainers = new PartContainerGroup<NonAppearancePart>[0];
             template.appearance = new AppearanceContainer();
 
             NpcTemplate.allNpcTemplates.templates.Add(template);
@@ -426,4 +425,3 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
     }
 }
 
-#endif

--- a/Crucible.GameAPI/CrucibleIngredient.cs
+++ b/Crucible.GameAPI/CrucibleIngredient.cs
@@ -19,7 +19,9 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using global::PotionCraft.Assemblies.GamepadNavigation;
     using global::PotionCraft.LocalizationSystem;
+    using global::PotionCraft.ObjectBased;
     using global::PotionCraft.ObjectBased.InteractiveItem.SoundControllers;
     using global::PotionCraft.ObjectBased.RecipeMap.Path;
     using global::PotionCraft.ObjectBased.Stack;
@@ -32,6 +34,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
     using RoboPhredDev.PotionCraft.Crucible.GameAPI.BackwardsCompatibility;
     using RoboPhredDev.PotionCraft.Crucible.GameAPI.GameHooks;
     using UnityEngine;
+    using UnityEngine.Rendering;
 
     /// <summary>
     /// Provides a stable API for working with PotionCraft <see cref="Ingredient"/>s.
@@ -437,6 +440,14 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             // It seems to remove itself automatically, as this component does not exist when inspecting the game object later.
             prefab.AddComponent<SortingOrderSetter>();
 
+            var slotObject = new GameObject
+            {
+                name = "Slot Object",
+            };
+            slotObject.transform.parent = prefab.transform;
+            slotObject.AddComponent<Slot>();
+            slotObject.AddComponent<ItemFromInventorySectionFinder>();
+
             foreach (var rootItem in rootItems)
             {
                 var stackItemGO = this.CreateStackItem(rootItem);
@@ -636,6 +647,8 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             ifs.colliderOuter = colliderOuter;
             ifs.colliderInner = colliderInner;
             ifs.NextStagePrefabs = crucibleStackItem.GrindChildren.Select(x => this.CreateStackItem(x, depth + 1)).ToArray();
+
+            var sortGroup = stackItem.AddComponent<SortingGroup>();
 
             return stackItem;
         }

--- a/Crucible.GameAPI/CrucibleInventoryItem.cs
+++ b/Crucible.GameAPI/CrucibleInventoryItem.cs
@@ -81,6 +81,11 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
         }
 
         /// <summary>
+        /// Gets or sets the required closeness level for this item to appear in a trader's inventory.
+        /// </summary>
+        public int ClosenessRequirement { get; set; }
+
+        /// <summary>
         /// Gets the game item being controlled by this api wrapper.
         /// </summary>
         internal InventoryItem InventoryItem { get; }

--- a/Crucible.GameAPI/CrucibleNpcAppearance.cs
+++ b/Crucible.GameAPI/CrucibleNpcAppearance.cs
@@ -547,6 +547,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             var part = this.npcTemplate.baseParts.OfType<T>().FirstOrDefault();
             if (part == null)
             {
+                // TODO Depending on the intended use case of this method npcTemplate.closenessParts may also need be checked.
                 throw new InvalidOperationException($"NPC template {this.npcTemplate.name} does not have a {typeof(T).Name} part.");
             }
 

--- a/Crucible.GameAPI/CrucibleNpcTemplate.cs
+++ b/Crucible.GameAPI/CrucibleNpcTemplate.cs
@@ -224,7 +224,6 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             return tags.ToArray();
         }
 
-#if DISABLED_FOR_0_5
         /// <summary>
         /// If this NPC Template is a customer, gets the API object for manipulating its customer data.
         /// </summary>
@@ -238,7 +237,6 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
 
             return new CrucibleCustomerNpcTemplate(this.NpcTemplate);
         }
-#endif
 
         /// <summary>
         /// If this NPC Template is a trader, gets the API object for manipulating its trader data.

--- a/Crucible.GameAPI/CrucibleNpcTemplate.cs
+++ b/Crucible.GameAPI/CrucibleNpcTemplate.cs
@@ -34,31 +34,21 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
 
         static CrucibleNpcTemplate()
         {
-            // FIXME: Tag new templates
-            var groundhogDayTags = new[] { CrucibleNpcTemplateTags.IsGroundhogDayNpc };
-
+            // TODO: Groundhog day templates no longer exist in the templates list. All Groundhog day traders in Potion Craft v0.5.0 do not use the new closeness system and appear to be non-funtional.
             var herbalistTags = new[] { CrucibleNpcTemplateTags.SellsHerbs, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsHerbalist };
             NpcTemplateTagsById.Add("Herbalist", new HashSet<string>(herbalistTags));
 
-            // NpcTemplateTagsById.Add("Demo2GroundHogDayHerbalistNpc", new HashSet<string>(herbalistTags.Concat(groundhogDayTags)));
             var mushroomerTags = new[] { CrucibleNpcTemplateTags.SellsMushrooms, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsMushroomer };
             NpcTemplateTagsById.Add("Mushroomer", new HashSet<string>(mushroomerTags));
 
-            // NpcTemplateTagsById.Add("Demo2GroundHogDayMushroomerNpc", new HashSet<string>(mushroomerTags.Concat(groundhogDayTags)));
             var alchemistTags = new[] { CrucibleNpcTemplateTags.SellsAlchemyMachine, CrucibleNpcTemplateTags.IsAlchemist };
             NpcTemplateTagsById.Add("Alchemist", new HashSet<string>(alchemistTags));
 
-
-            // NpcTemplateTagsById.Add("Playtest2GroundHogDayAlchemistNpc", new HashSet<string>(alchemistTags.Concat(groundhogDayTags)));
             var dwarfTags = new[] { CrucibleNpcTemplateTags.SellsCrystals, CrucibleNpcTemplateTags.SellsInorganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsDwarfMiner };
             NpcTemplateTagsById.Add("Dwarf", new HashSet<string>(dwarfTags));
 
-            // NpcTemplateTagsById.Add("Playtest2GroundHogDayDwarfMinerNpc", new HashSet<string>(dwarfTags.Concat(groundhogDayTags)));
             var merchantTags = new[] { CrucibleNpcTemplateTags.SellsHerbs, CrucibleNpcTemplateTags.SellsMushrooms, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsInorganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsTravelingMerchant };
             NpcTemplateTagsById.Add("WMerchant", new HashSet<string>(merchantTags));
-
-            // NpcTemplateTagsById.Add("Demo2GroundHogDayWanderingMerchantNpc 1", new HashSet<string>(merchantTags.Concat(groundhogDayTags)));
-            // NpcTemplateTagsById.Add("Demo2GroundHogDayWanderingMerchantNpc 2", new HashSet<string>(merchantTags.Concat(groundhogDayTags)));
         }
 
         /// <summary>

--- a/Crucible.GameAPI/CrucibleNpcTemplate.cs
+++ b/Crucible.GameAPI/CrucibleNpcTemplate.cs
@@ -23,6 +23,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
     using global::PotionCraft.Npc.Parts;
     using global::PotionCraft.Npc.Parts.Settings;
     using global::PotionCraft.QuestSystem;
+    using UnityEngine;
 
     /// <summary>
     /// Provides a stable API for working with PotionCraft <see cref="NpcTemplate"/>s.
@@ -34,50 +35,50 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
         static CrucibleNpcTemplate()
         {
             // FIXME: Tag new templates
-            // var groundhogDayTags = new[] { CrucibleNpcTemplateTags.IsGroundhogDayNpc };
+            var groundhogDayTags = new[] { CrucibleNpcTemplateTags.IsGroundhogDayNpc };
 
-            // var herbalistTags = new[] { CrucibleNpcTemplateTags.SellsHerbs, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsHerbalist };
-            // NpcTemplateTagsById.Add("HerbalistNpc 1", new HashSet<string>(herbalistTags));
-            // NpcTemplateTagsById.Add("HerbalistNpc 2", new HashSet<string>(herbalistTags));
-            // NpcTemplateTagsById.Add("HerbalistNpc 3", new HashSet<string>(herbalistTags));
-            // NpcTemplateTagsById.Add("HerbalistNpc 4", new HashSet<string>(herbalistTags));
-            // NpcTemplateTagsById.Add("HerbalistNpc 5", new HashSet<string>(herbalistTags));
-            // NpcTemplateTagsById.Add("HerbalistNpc 6", new HashSet<string>(herbalistTags));
-            // NpcTemplateTagsById.Add("HerbalistNpc 7", new HashSet<string>(herbalistTags));
-            // NpcTemplateTagsById.Add("HerbalistNpc 8", new HashSet<string>(herbalistTags));
-            // NpcTemplateTagsById.Add("Demo2GroundHogDayHerbalistNpc", new HashSet<string>(herbalistTags.Concat(groundhogDayTags)));
+            var herbalistTags = new[] { CrucibleNpcTemplateTags.SellsHerbs, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsHerbalist };
+            NpcTemplateTagsById.Add("HerbalistNpc 1", new HashSet<string>(herbalistTags));
+            NpcTemplateTagsById.Add("HerbalistNpc 2", new HashSet<string>(herbalistTags));
+            NpcTemplateTagsById.Add("HerbalistNpc 3", new HashSet<string>(herbalistTags));
+            NpcTemplateTagsById.Add("HerbalistNpc 4", new HashSet<string>(herbalistTags));
+            NpcTemplateTagsById.Add("HerbalistNpc 5", new HashSet<string>(herbalistTags));
+            NpcTemplateTagsById.Add("HerbalistNpc 6", new HashSet<string>(herbalistTags));
+            NpcTemplateTagsById.Add("HerbalistNpc 7", new HashSet<string>(herbalistTags));
+            NpcTemplateTagsById.Add("HerbalistNpc 8", new HashSet<string>(herbalistTags));
+            NpcTemplateTagsById.Add("Demo2GroundHogDayHerbalistNpc", new HashSet<string>(herbalistTags.Concat(groundhogDayTags)));
 
-            // var mushroomerTags = new[] { CrucibleNpcTemplateTags.SellsMushrooms, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsMushroomer };
-            // NpcTemplateTagsById.Add("MushroomerNpc 1", new HashSet<string>(mushroomerTags));
-            // NpcTemplateTagsById.Add("MushroomerNpc 2", new HashSet<string>(mushroomerTags));
-            // NpcTemplateTagsById.Add("MushroomerNpc 3", new HashSet<string>(mushroomerTags));
-            // NpcTemplateTagsById.Add("MushroomerNpc 4", new HashSet<string>(mushroomerTags));
-            // NpcTemplateTagsById.Add("MushroomerNpc 5", new HashSet<string>(mushroomerTags));
-            // NpcTemplateTagsById.Add("MushroomerNpc 6", new HashSet<string>(mushroomerTags));
-            // NpcTemplateTagsById.Add("MushroomerNpc 7", new HashSet<string>(mushroomerTags));
-            // NpcTemplateTagsById.Add("Demo2GroundHogDayMushroomerNpc", new HashSet<string>(mushroomerTags.Concat(groundhogDayTags)));
+            var mushroomerTags = new[] { CrucibleNpcTemplateTags.SellsMushrooms, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsMushroomer };
+            NpcTemplateTagsById.Add("MushroomerNpc 1", new HashSet<string>(mushroomerTags));
+            NpcTemplateTagsById.Add("MushroomerNpc 2", new HashSet<string>(mushroomerTags));
+            NpcTemplateTagsById.Add("MushroomerNpc 3", new HashSet<string>(mushroomerTags));
+            NpcTemplateTagsById.Add("MushroomerNpc 4", new HashSet<string>(mushroomerTags));
+            NpcTemplateTagsById.Add("MushroomerNpc 5", new HashSet<string>(mushroomerTags));
+            NpcTemplateTagsById.Add("MushroomerNpc 6", new HashSet<string>(mushroomerTags));
+            NpcTemplateTagsById.Add("MushroomerNpc 7", new HashSet<string>(mushroomerTags));
+            NpcTemplateTagsById.Add("Demo2GroundHogDayMushroomerNpc", new HashSet<string>(mushroomerTags.Concat(groundhogDayTags)));
 
-            // var alchemistTags = new[] { CrucibleNpcTemplateTags.SellsAlchemyMachine, CrucibleNpcTemplateTags.IsAlchemist };
-            // NpcTemplateTagsById.Add("AlchemistNpc 1", new HashSet<string>(alchemistTags));
-            // NpcTemplateTagsById.Add("AlchemistNpc 2", new HashSet<string>(alchemistTags));
-            // NpcTemplateTagsById.Add("AlchemistNpc 3", new HashSet<string>(alchemistTags));
-            // NpcTemplateTagsById.Add("AlchemistNpc 4", new HashSet<string>(alchemistTags));
-            // NpcTemplateTagsById.Add("AlchemistNpc 5", new HashSet<string>(alchemistTags));
-            // NpcTemplateTagsById.Add("AlchemistNpc 6", new HashSet<string>(alchemistTags));
-            // NpcTemplateTagsById.Add("Playtest2GroundHogDayAlchemistNpc", new HashSet<string>(alchemistTags.Concat(groundhogDayTags)));
+            var alchemistTags = new[] { CrucibleNpcTemplateTags.SellsAlchemyMachine, CrucibleNpcTemplateTags.IsAlchemist };
+            NpcTemplateTagsById.Add("AlchemistNpc 1", new HashSet<string>(alchemistTags));
+            NpcTemplateTagsById.Add("AlchemistNpc 2", new HashSet<string>(alchemistTags));
+            NpcTemplateTagsById.Add("AlchemistNpc 3", new HashSet<string>(alchemistTags));
+            NpcTemplateTagsById.Add("AlchemistNpc 4", new HashSet<string>(alchemistTags));
+            NpcTemplateTagsById.Add("AlchemistNpc 5", new HashSet<string>(alchemistTags));
+            NpcTemplateTagsById.Add("AlchemistNpc 6", new HashSet<string>(alchemistTags));
+            NpcTemplateTagsById.Add("Playtest2GroundHogDayAlchemistNpc", new HashSet<string>(alchemistTags.Concat(groundhogDayTags)));
 
-            // var dwarfTags = new[] { CrucibleNpcTemplateTags.SellsCrystals, CrucibleNpcTemplateTags.SellsInorganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsDwarfMiner };
-            // NpcTemplateTagsById.Add("DwarfMinerNpc 1", new HashSet<string>(dwarfTags));
-            // NpcTemplateTagsById.Add("DwarfMinerNpc 2", new HashSet<string>(dwarfTags));
-            // NpcTemplateTagsById.Add("DwarfMinerNpc 3", new HashSet<string>(dwarfTags));
-            // NpcTemplateTagsById.Add("DwarfMinerNpc 4", new HashSet<string>(dwarfTags));
-            // NpcTemplateTagsById.Add("Playtest2GroundHogDayDwarfMinerNpc", new HashSet<string>(dwarfTags.Concat(groundhogDayTags)));
+            var dwarfTags = new[] { CrucibleNpcTemplateTags.SellsCrystals, CrucibleNpcTemplateTags.SellsInorganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsDwarfMiner };
+            NpcTemplateTagsById.Add("DwarfMinerNpc 1", new HashSet<string>(dwarfTags));
+            NpcTemplateTagsById.Add("DwarfMinerNpc 2", new HashSet<string>(dwarfTags));
+            NpcTemplateTagsById.Add("DwarfMinerNpc 3", new HashSet<string>(dwarfTags));
+            NpcTemplateTagsById.Add("DwarfMinerNpc 4", new HashSet<string>(dwarfTags));
+            NpcTemplateTagsById.Add("Playtest2GroundHogDayDwarfMinerNpc", new HashSet<string>(dwarfTags.Concat(groundhogDayTags)));
 
-            // var merchantTags = new[] { CrucibleNpcTemplateTags.SellsHerbs, CrucibleNpcTemplateTags.SellsMushrooms, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsInorganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsTravelingMerchant };
-            // NpcTemplateTagsById.Add("WanderingMerchantNpc 1", new HashSet<string>(merchantTags));
-            // NpcTemplateTagsById.Add("WanderingMerchantNpc 2", new HashSet<string>(merchantTags));
-            // NpcTemplateTagsById.Add("Demo2GroundHogDayWanderingMerchantNpc 1", new HashSet<string>(merchantTags.Concat(groundhogDayTags)));
-            // NpcTemplateTagsById.Add("Demo2GroundHogDayWanderingMerchantNpc 2", new HashSet<string>(merchantTags.Concat(groundhogDayTags)));
+            var merchantTags = new[] { CrucibleNpcTemplateTags.SellsHerbs, CrucibleNpcTemplateTags.SellsMushrooms, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsInorganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsTravelingMerchant };
+            NpcTemplateTagsById.Add("WanderingMerchantNpc 1", new HashSet<string>(merchantTags));
+            NpcTemplateTagsById.Add("WanderingMerchantNpc 2", new HashSet<string>(merchantTags));
+            NpcTemplateTagsById.Add("Demo2GroundHogDayWanderingMerchantNpc 1", new HashSet<string>(merchantTags.Concat(groundhogDayTags)));
+            NpcTemplateTagsById.Add("Demo2GroundHogDayWanderingMerchantNpc 2", new HashSet<string>(merchantTags.Concat(groundhogDayTags)));
         }
 
         /// <summary>

--- a/Crucible.GameAPI/CrucibleNpcTemplate.cs
+++ b/Crucible.GameAPI/CrucibleNpcTemplate.cs
@@ -38,47 +38,27 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             var groundhogDayTags = new[] { CrucibleNpcTemplateTags.IsGroundhogDayNpc };
 
             var herbalistTags = new[] { CrucibleNpcTemplateTags.SellsHerbs, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsHerbalist };
-            NpcTemplateTagsById.Add("HerbalistNpc 1", new HashSet<string>(herbalistTags));
-            NpcTemplateTagsById.Add("HerbalistNpc 2", new HashSet<string>(herbalistTags));
-            NpcTemplateTagsById.Add("HerbalistNpc 3", new HashSet<string>(herbalistTags));
-            NpcTemplateTagsById.Add("HerbalistNpc 4", new HashSet<string>(herbalistTags));
-            NpcTemplateTagsById.Add("HerbalistNpc 5", new HashSet<string>(herbalistTags));
-            NpcTemplateTagsById.Add("HerbalistNpc 6", new HashSet<string>(herbalistTags));
-            NpcTemplateTagsById.Add("HerbalistNpc 7", new HashSet<string>(herbalistTags));
-            NpcTemplateTagsById.Add("HerbalistNpc 8", new HashSet<string>(herbalistTags));
-            NpcTemplateTagsById.Add("Demo2GroundHogDayHerbalistNpc", new HashSet<string>(herbalistTags.Concat(groundhogDayTags)));
+            NpcTemplateTagsById.Add("Herbalist", new HashSet<string>(herbalistTags));
 
+            // NpcTemplateTagsById.Add("Demo2GroundHogDayHerbalistNpc", new HashSet<string>(herbalistTags.Concat(groundhogDayTags)));
             var mushroomerTags = new[] { CrucibleNpcTemplateTags.SellsMushrooms, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsMushroomer };
-            NpcTemplateTagsById.Add("MushroomerNpc 1", new HashSet<string>(mushroomerTags));
-            NpcTemplateTagsById.Add("MushroomerNpc 2", new HashSet<string>(mushroomerTags));
-            NpcTemplateTagsById.Add("MushroomerNpc 3", new HashSet<string>(mushroomerTags));
-            NpcTemplateTagsById.Add("MushroomerNpc 4", new HashSet<string>(mushroomerTags));
-            NpcTemplateTagsById.Add("MushroomerNpc 5", new HashSet<string>(mushroomerTags));
-            NpcTemplateTagsById.Add("MushroomerNpc 6", new HashSet<string>(mushroomerTags));
-            NpcTemplateTagsById.Add("MushroomerNpc 7", new HashSet<string>(mushroomerTags));
-            NpcTemplateTagsById.Add("Demo2GroundHogDayMushroomerNpc", new HashSet<string>(mushroomerTags.Concat(groundhogDayTags)));
+            NpcTemplateTagsById.Add("Mushroomer", new HashSet<string>(mushroomerTags));
 
+            // NpcTemplateTagsById.Add("Demo2GroundHogDayMushroomerNpc", new HashSet<string>(mushroomerTags.Concat(groundhogDayTags)));
             var alchemistTags = new[] { CrucibleNpcTemplateTags.SellsAlchemyMachine, CrucibleNpcTemplateTags.IsAlchemist };
-            NpcTemplateTagsById.Add("AlchemistNpc 1", new HashSet<string>(alchemistTags));
-            NpcTemplateTagsById.Add("AlchemistNpc 2", new HashSet<string>(alchemistTags));
-            NpcTemplateTagsById.Add("AlchemistNpc 3", new HashSet<string>(alchemistTags));
-            NpcTemplateTagsById.Add("AlchemistNpc 4", new HashSet<string>(alchemistTags));
-            NpcTemplateTagsById.Add("AlchemistNpc 5", new HashSet<string>(alchemistTags));
-            NpcTemplateTagsById.Add("AlchemistNpc 6", new HashSet<string>(alchemistTags));
-            NpcTemplateTagsById.Add("Playtest2GroundHogDayAlchemistNpc", new HashSet<string>(alchemistTags.Concat(groundhogDayTags)));
+            NpcTemplateTagsById.Add("Alchemist", new HashSet<string>(alchemistTags));
 
+
+            // NpcTemplateTagsById.Add("Playtest2GroundHogDayAlchemistNpc", new HashSet<string>(alchemistTags.Concat(groundhogDayTags)));
             var dwarfTags = new[] { CrucibleNpcTemplateTags.SellsCrystals, CrucibleNpcTemplateTags.SellsInorganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsDwarfMiner };
-            NpcTemplateTagsById.Add("DwarfMinerNpc 1", new HashSet<string>(dwarfTags));
-            NpcTemplateTagsById.Add("DwarfMinerNpc 2", new HashSet<string>(dwarfTags));
-            NpcTemplateTagsById.Add("DwarfMinerNpc 3", new HashSet<string>(dwarfTags));
-            NpcTemplateTagsById.Add("DwarfMinerNpc 4", new HashSet<string>(dwarfTags));
-            NpcTemplateTagsById.Add("Playtest2GroundHogDayDwarfMinerNpc", new HashSet<string>(dwarfTags.Concat(groundhogDayTags)));
+            NpcTemplateTagsById.Add("Dwarf", new HashSet<string>(dwarfTags));
 
+            // NpcTemplateTagsById.Add("Playtest2GroundHogDayDwarfMinerNpc", new HashSet<string>(dwarfTags.Concat(groundhogDayTags)));
             var merchantTags = new[] { CrucibleNpcTemplateTags.SellsHerbs, CrucibleNpcTemplateTags.SellsMushrooms, CrucibleNpcTemplateTags.SellsOrganic, CrucibleNpcTemplateTags.SellsInorganic, CrucibleNpcTemplateTags.SellsIngredients, CrucibleNpcTemplateTags.IsTravelingMerchant };
-            NpcTemplateTagsById.Add("WanderingMerchantNpc 1", new HashSet<string>(merchantTags));
-            NpcTemplateTagsById.Add("WanderingMerchantNpc 2", new HashSet<string>(merchantTags));
-            NpcTemplateTagsById.Add("Demo2GroundHogDayWanderingMerchantNpc 1", new HashSet<string>(merchantTags.Concat(groundhogDayTags)));
-            NpcTemplateTagsById.Add("Demo2GroundHogDayWanderingMerchantNpc 2", new HashSet<string>(merchantTags.Concat(groundhogDayTags)));
+            NpcTemplateTagsById.Add("WMerchant", new HashSet<string>(merchantTags));
+
+            // NpcTemplateTagsById.Add("Demo2GroundHogDayWanderingMerchantNpc 1", new HashSet<string>(merchantTags.Concat(groundhogDayTags)));
+            // NpcTemplateTagsById.Add("Demo2GroundHogDayWanderingMerchantNpc 2", new HashSet<string>(merchantTags.Concat(groundhogDayTags)));
         }
 
         /// <summary>
@@ -109,7 +89,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
         /// <summary>
         /// Gets a value indicating whether this template is a trader.
         /// </summary>
-        public bool IsTrader => this.NpcTemplate.baseParts.Any(x => x is TraderSettings);
+        public bool IsTrader => this.NpcTemplate.closenessParts.Any(c => c.parts.Any(x => x is TraderSettings));
 
         /// <summary>
         /// Gets a value indicating whether this template is a customer.

--- a/Crucible.GameAPI/GameHooks/SaveLoadEvent.cs
+++ b/Crucible.GameAPI/GameHooks/SaveLoadEvent.cs
@@ -139,7 +139,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.GameHooks
         {
             var raiseGameLoadedMethodInfo = AccessTools.Method(typeof(SaveLoadEvent), nameof(RaiseGameLoaded));
 
-            var loadFileMethodInfo = AccessTools.PropertyGetter(typeof(SaveLoadManager), nameof(SaveLoadManager.LoadFile));
+            var loadFileMethodInfo = AccessTools.Method(typeof(SaveLoadManager), nameof(SaveLoadManager.LoadFile));
 
             var found = false;
             foreach (var instruction in instructions)

--- a/Crucible.Ingredients/CrucibleIngredientConfig.cs
+++ b/Crucible.Ingredients/CrucibleIngredientConfig.cs
@@ -102,6 +102,11 @@ namespace RoboPhredDev.PotionCraft.Crucible.Ingredients
         /// </summary>
         public bool? IsStackItemsSolid { get; set; }
 
+        /// <summary>
+        /// Gets or sets the closeness requirement for this ingredient to show up in a trader's inventory.
+        /// </summary>
+        public int? ClosenessRequirement { get; set; }
+
         /// <inheritdoc/>
         public override string ToString()
         {
@@ -185,6 +190,11 @@ namespace RoboPhredDev.PotionCraft.Crucible.Ingredients
             if (this.IsStackItemsSolid.HasValue)
             {
                 subject.IsStackItemSolid = this.IsStackItemsSolid.Value;
+            }
+
+            if (this.ClosenessRequirement.HasValue)
+            {
+                subject.ClosenessRequirement = this.ClosenessRequirement.Value;
             }
         }
     }

--- a/Crucible.NPCs/CrucibleCustomerConfig.cs
+++ b/Crucible.NPCs/CrucibleCustomerConfig.cs
@@ -14,7 +14,7 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
-#if DISABLED_FOR_0_5
+
 
 namespace RoboPhredDev.PotionCraft.Crucible.NPCs
 {
@@ -105,4 +105,4 @@ namespace RoboPhredDev.PotionCraft.Crucible.NPCs
     }
 }
 
-#endif
+

--- a/Crucible.NPCs/CrucibleCustomersConfigRoot.cs
+++ b/Crucible.NPCs/CrucibleCustomersConfigRoot.cs
@@ -14,7 +14,6 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
-#if DISABLED_FOR_0_5
 
 namespace RoboPhredDev.PotionCraft.Crucible.NPCs
 {
@@ -40,4 +39,3 @@ namespace RoboPhredDev.PotionCraft.Crucible.NPCs
     }
 }
 
-#endif

--- a/Crucible.NPCs/CrucibleNpcCalendarVisitConfig.cs
+++ b/Crucible.NPCs/CrucibleNpcCalendarVisitConfig.cs
@@ -14,7 +14,6 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
-#if DISABLED_FOR_0_5
 
 namespace RoboPhredDev.PotionCraft.Crucible.NPCs
 {
@@ -43,11 +42,10 @@ namespace RoboPhredDev.PotionCraft.Crucible.NPCs
             }
 
             // TODO: Allow adding to start / middle / end / before npc / after npc
-            CrucibleDayManager.BackfillDaysTo(this.Day);
-            var count = CrucibleDayManager.GetNpcTemplatesForDay(this.Day).Count();
-            CrucibleDayManager.InsertNpcTemplateToDay(this.Day, count, npcTemplate);
+            //CrucibleDayManager.BackfillDaysTo(this.Day);
+            //var count = CrucibleDayManager.GetNpcTemplatesForDay(this.Day).Count();
+            //CrucibleDayManager.InsertNpcTemplateToDay(this.Day, count, npcTemplate);
         }
     }
 }
 
-#endif


### PR DESCRIPTION
- Fixed hook into file load event
- Enabled some disabled code and fixed build errors
- Added backwards compatibility for ingredients so existing mods can continue to function without updating ingredient ids
- Added new configuration option for custom ingredients: closenessRequirement
- This new configuration option allows modders to decide what closeness level is required for their ingredient to show up in a trader's inventory
- Fixed npc trader template loading to use new template names