### PR TITLE
Updated Crucible.Ingredients to work with Potion Craft 1.0

### DIFF
--- a/Crucible.GameAPI/Crucible.GameAPI.csproj
+++ b/Crucible.GameAPI/Crucible.GameAPI.csproj
@@ -37,8 +37,8 @@
     <Reference Include="Unity.TextMeshPro" CopyToPublishDirectory="Never">
       <HintPath>..\externals\Unity.TextMeshPro.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.TextCoreModule" CopyToPublishDirectory="Never">
-      <HintPath>..\externals\UnityEngine.TextCoreModule.dll</HintPath>
+    <Reference Include="UnityEngine.TextCoreFontEngineModule">
+      <HintPath>..\externals\UnityEngine.TextCoreFontEngineModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.Physics2DModule" CopyToPublishDirectory="Never">
       <HintPath>..\externals\UnityEngine.Physics2DModule.dll</HintPath>
@@ -64,6 +64,12 @@
     </Reference>
     <Reference Include="PotionCraft.Settings" CopyToPublishDirectory="Never">
       <HintPath>..\externals\PotionCraft.Settings.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TextCoreTextEngineModule">
+      <HintPath>..\externals\UnityEngine.TextCoreTextEngineModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <HintPath>..\externals\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Crucible.GameAPI/CrucibleCustomerNpcTemplate.cs
+++ b/Crucible.GameAPI/CrucibleCustomerNpcTemplate.cs
@@ -145,7 +145,8 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             // var npcPrefab = UnityEngine.Object.Instantiate(parentPrefab.prefab);
             // npcPrefab.transform.parent = GameObjectUtilities.CruciblePrefabRoot;
 
-            prefab.prefab = parentPrefab.prefab;
+            // TODO Fahlgorithm not sure if this is still a thing
+            // prefab.prefab = parentPrefab.prefab;
             prefab.clothesColorPalette1 = parentPrefab.clothesColorPalette1;
             prefab.clothesColorPalette2 = parentPrefab.clothesColorPalette2;
             prefab.clothesColorPalette3 = parentPrefab.clothesColorPalette3;

--- a/Crucible.GameAPI/CrucibleIngredient.cs
+++ b/Crucible.GameAPI/CrucibleIngredient.cs
@@ -491,6 +491,12 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             }
 
             this.Ingredient.path.path = list;
+            this.Ingredient.path.CalculateEvenlySpacedPoints();
+
+            // This will calculate element potentials for the ingredient based on path
+            // It appears that normally this is done as a build task and so there exists no calls to this method in code
+            // TODO is there a way to cache this to a prefab similarly to how it is being done in game?
+            Traverse.Create(this.Ingredient).Method("CalculatePotentials", new[] { typeof(IngredientPath) }).GetValue(this.Ingredient.path);
         }
 
         private static Ingredient GetBaseIngredientForOldId(string oldId)

--- a/Crucible.GameAPI/CrucibleNpcAppearance.cs
+++ b/Crucible.GameAPI/CrucibleNpcAppearance.cs
@@ -30,7 +30,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
     {
         private static readonly Sprite BlankSprite = SpriteUtilities.CreateBlankSprite(1, 1, Color.clear).WithName("Crucible cleared appearance sprite");
 
-        private static readonly AppearancePart.ColorablePart BlankColorablePart = new()
+        private static readonly ColorablePart BlankColorablePart = new()
         {
             background = BlankSprite,
             contour = BlankSprite,
@@ -120,7 +120,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
         {
             var skullShape = ScriptableObject.CreateInstance<SkullShape>();
             skullShape.mask = mask;
-            skullShape.shape = new AppearancePart.ColorablePart
+            skullShape.shape = new ColorablePart
             {
                 background = background,
                 contour = contour,
@@ -484,7 +484,8 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
 
             var sourceTemplate = sourceAppearance.npcTemplate;
 
-            prefab.prefab = sourcePrefab.prefab;
+            // TOOD Fahlgorithm not sure if this is still a thing
+            // prefab.prefab = sourcePrefab.prefab;
             prefab.clothesColorPalette1 = sourcePrefab.clothesColorPalette1;
             prefab.clothesColorPalette2 = sourcePrefab.clothesColorPalette2;
             prefab.clothesColorPalette3 = sourcePrefab.clothesColorPalette3;
@@ -589,14 +590,14 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             /// Sets the appearance data in the array.
             /// </summary>
             /// <param name="parts">The array to set data for.</param>
-            internal void Set(AppearancePart.ColorablePart[] parts)
+            internal void Set(ColorablePart[] parts)
             {
                 if (parts.Length <= this.index)
                 {
                     throw new InvalidOperationException("Part array is too small.");
                 }
 
-                parts[this.index] = new AppearancePart.ColorablePart
+                parts[this.index] = new ColorablePart
                 {
                     background = this.Background ?? BlankSprite,
                     contour = this.Contour ?? BlankSprite,

--- a/Crucible.GameAPI/CruciblePotionBase.cs
+++ b/Crucible.GameAPI/CruciblePotionBase.cs
@@ -14,6 +14,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
 {
     using System;
@@ -366,20 +368,22 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             newBase.mapItemSprite = waterBase.mapItemSprite;
             newBase.recipeMapIconSprite = waterBase.recipeMapIconSprite;
 
-            var index = MapLoader.loadedMaps.Count;
+            var index = MapStatesManager.MapStates.Length;
             var mapState = new MapState
             {
                 index = index,
                 zoom = Settings<RecipeMapManagerSettings>.Asset.zoomSettings.defaultZoom,
                 potionBase = newBase,
             };
-            MapLoader.loadedMaps.Add(mapState);
+            var newMapStates = MapStatesManager.MapStates.Concat(new[] { mapState }).ToArray();
+            var mapStatesField = typeof(MapStatesManager).GetField("_mapStates");
+            mapStatesField.SetValue(null, newMapStates);
 
             var oldCurrentMap = Managers.RecipeMap.currentMap;
             Managers.RecipeMap.currentMap = mapState;
             try
             {
-                mapState.transform = Traverse.Create(typeof(MapLoader)).Method("InstantiateMap", new[] { typeof(int) }).GetValue<Transform>(index);
+                mapState.transform = Traverse.Create(typeof(MapStatesManager)).Method("InstantiateMap", new[] { typeof(int) }).GetValue<Transform>(index);
                 mapState.transform.gameObject.name = $"Crucible RecipeMap {id}";
                 mapState.transform.GetComponent<RecipeMapPrefabController>().mapState = mapState;
 
@@ -553,3 +557,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
         }
     }
 }
+
+#endif

--- a/Crucible.GameAPI/CruciblePotionEffect.cs
+++ b/Crucible.GameAPI/CruciblePotionEffect.cs
@@ -396,12 +396,12 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
 
         private static void TryResolveSettingsFromMap(PotionEffect effect)
         {
-            foreach (var mapState in MapLoader.loadedMaps)
+            foreach (var mapState in MapStatesManager.MapStates)
             {
                 var mapObject = mapState.transform.gameObject;
                 foreach (var potionEffectItem in mapObject.GetComponentsInChildren<PotionEffectMapItem>())
                 {
-                    if (potionEffectItem.effect != effect)
+                    if (potionEffectItem.Effect != effect)
                     {
                         continue;
                     }
@@ -419,7 +419,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
         {
             // FIXME: We might capture a custom potion effect here, which might have customized
             // bottle sprites.  We should restrict our search to base game effects.
-            foreach (var mapState in MapLoader.loadedMaps)
+            foreach (var mapState in MapStatesManager.MapStates)
             {
                 var mapObject = mapState.transform.gameObject;
                 var mapItem = mapObject.GetComponentInChildren<PotionEffectMapItem>();

--- a/Crucible.GameAPI/GameHooks/IconsResolveAtlasEvent.cs
+++ b/Crucible.GameAPI/GameHooks/IconsResolveAtlasEvent.cs
@@ -22,6 +22,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.GameHooks
     using global::PotionCraft.ManagersSystem.TMP;
     using global::PotionCraft.ObjectBased.UIElements.Books.RecipeBook;
     using global::PotionCraft.ScriptableObjects;
+    using global::PotionCraft.ScriptableObjects.Potion;
     using global::PotionCraft.Settings;
     using HarmonyLib;
     using UnityEngine;

--- a/Crucible.GameAPI/GameHooks/IngredientsListResolveAtlasEvent.cs
+++ b/Crucible.GameAPI/GameHooks/IngredientsListResolveAtlasEvent.cs
@@ -25,7 +25,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.GameHooks
     using global::PotionCraft.ObjectBased.Mortar;
     using global::PotionCraft.ObjectBased.UIElements.Books.RecipeBook;
     using global::PotionCraft.ObjectBased.UIElements.PotionCraftPanel;
-    using global::PotionCraft.ScriptableObjects;
+    using global::PotionCraft.ScriptableObjects.Potion;
     using global::PotionCraft.Settings;
     using HarmonyLib;
     using UnityEngine;
@@ -106,7 +106,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.GameHooks
             return GetAtlasForUsedComponent(component);
         }
 
-        private static string GetAtlasForUsedComponent(Potion.UsedComponent component)
+        private static string GetAtlasForUsedComponent(PotionUsedComponent component)
         {
             return GetAtlasForScriptableObject(component.componentObject);
         }
@@ -156,7 +156,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.GameHooks
             var found = false;
             foreach (var instruction in instructions)
             {
-                if (!found && instruction.opcode == OpCodes.Ldloc_S && instruction.operand is LocalBuilder localBuilder && localBuilder.LocalIndex == 5 && localBuilder.LocalType == typeof(Potion.UsedComponent))
+                if (!found && instruction.opcode == OpCodes.Ldloc_S && instruction.operand is LocalBuilder localBuilder && localBuilder.LocalIndex == 5 && localBuilder.LocalType == typeof(PotionUsedComponent))
                 {
                     // We should now be right before the if statement checking if the current potion is in stock
                     found = true;
@@ -186,7 +186,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.GameHooks
         {
             var getAtlasForPotionUsedComponentIndex = AccessTools.Method(typeof(IngredientsListResolveAtlasEvent), nameof(GetAtlasForPotionUsedComponentIndex));
             var usedComponentsField = AccessTools.Field(typeof(Potion), nameof(Potion.usedComponents));
-            var componentObjectField = AccessTools.Field(typeof(Potion.UsedComponent), nameof(Potion.UsedComponent.componentObject));
+            var componentObjectField = AccessTools.Field(typeof(PotionUsedComponent), nameof(PotionUsedComponent.componentObject));
             var found = false;
             foreach (var instruction in instructions)
             {

--- a/Crucible.GameAPI/MapEntities/CrucibleMapEntitySpawner.cs
+++ b/Crucible.GameAPI/MapEntities/CrucibleMapEntitySpawner.cs
@@ -14,6 +14,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.MapEntities
 {
     using System;
@@ -131,3 +133,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.MapEntities
         }
     }
 }
+
+#endif

--- a/Crucible.GameAPI/MapEntities/CrucibleMapEntitySpawnerExtensions.cs
+++ b/Crucible.GameAPI/MapEntities/CrucibleMapEntitySpawnerExtensions.cs
@@ -14,6 +14,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.MapEntities
 {
     using UnityEngine;
@@ -59,3 +61,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.MapEntities
         }
     }
 }
+
+#endif

--- a/Crucible.GameAPI/MapEntities/CruciblePotionEffectEntityFactory.cs
+++ b/Crucible.GameAPI/MapEntities/CruciblePotionEffectEntityFactory.cs
@@ -14,6 +14,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.MapEntities
 {
     using System;
@@ -84,7 +86,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.MapEntities
             go.name = $"Crucible PotionEffect {this.PotionEffect.ID}";
             var mapItem = go.GetComponent<PotionEffectMapItem>();
 
-            mapItem.effect = this.PotionEffect.PotionEffect;
+            mapItem.Effect = this.PotionEffect.PotionEffect;
             mapItem.Status = PotionEffectStatus.Unknown;
 
             Traverse.Create(mapItem).Field<PotionEffectSettings>("settings").Value = settings;
@@ -104,7 +106,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.MapEntities
                 return potionEffectPrefab;
             }
 
-            foreach (var mapState in MapLoader.loadedMaps)
+            foreach (var mapState in MapStatesManager.MapStates)
             {
                 var mapItem = mapState.transform.gameObject.GetComponentInChildren<PotionEffectMapItem>();
                 if (mapItem == null)
@@ -128,3 +130,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.MapEntities
         }
     }
 }
+
+#endif

--- a/Crucible.GameAPI/RecipeMapGameObjectUtilities.cs
+++ b/Crucible.GameAPI/RecipeMapGameObjectUtilities.cs
@@ -14,6 +14,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
 {
     using System;
@@ -158,3 +161,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
         }
     }
 }
+
+#endif

--- a/Crucible.PotionBases/CruciblePotionBaseConfig.cs
+++ b/Crucible.PotionBases/CruciblePotionBaseConfig.cs
@@ -14,6 +14,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.PotionBases
 {
     using System;
@@ -262,3 +264,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.PotionBases
         }
     }
 }
+
+#endif

--- a/Crucible.PotionBases/CruciblePotionBasesConfigRoot.cs
+++ b/Crucible.PotionBases/CruciblePotionBasesConfigRoot.cs
@@ -14,6 +14,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.PotionBases
 {
     using System.Collections.Generic;
@@ -37,3 +39,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.PotionBases
         }
     }
 }
+
+#endif

--- a/Crucible.PotionBases/CruciblePotionBasesPlugin.cs
+++ b/Crucible.PotionBases/CruciblePotionBasesPlugin.cs
@@ -14,6 +14,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.PotionBases
 {
     using BepInEx;
@@ -27,3 +29,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.PotionBases
     {
     }
 }
+
+#endif

--- a/Crucible.PotionBases/Entities/CrucibleDangerZonePartEntityConfig.cs
+++ b/Crucible.PotionBases/Entities/CrucibleDangerZonePartEntityConfig.cs
@@ -14,6 +14,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.PotionBases.Entities
 {
     using System;
@@ -95,3 +97,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.PotionBases.Entities
         }
     }
 }
+
+#endif

--- a/Crucible.PotionBases/Entities/CrucibleMapEntityConfig.cs
+++ b/Crucible.PotionBases/Entities/CrucibleMapEntityConfig.cs
@@ -14,6 +14,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.PotionBases.Entities
 {
     using RoboPhredDev.PotionCraft.Crucible.GameAPI.MapEntities;
@@ -33,3 +35,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.PotionBases.Entities
         public abstract void AddEntityToSpawner(string packageNamespace, CrucibleMapEntitySpawner spawner);
     }
 }
+
+#endif

--- a/Crucible.PotionBases/Entities/CruciblePotionEffectEntityConfig.cs
+++ b/Crucible.PotionBases/Entities/CruciblePotionEffectEntityConfig.cs
@@ -14,6 +14,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.PotionBases.Entities
 {
     using System;
@@ -102,3 +104,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.PotionBases.Entities
         }
     }
 }
+
+#endif

--- a/Crucible.PotionBases/Entities/CrucibleVortexEntityConfig.cs
+++ b/Crucible.PotionBases/Entities/CrucibleVortexEntityConfig.cs
@@ -14,6 +14,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // </copyright>
 
+#if CRUCIBLE_BASES
+
 namespace RoboPhredDev.PotionCraft.Crucible.PotionBases.Entities
 {
     using System;
@@ -90,3 +92,5 @@ namespace RoboPhredDev.PotionCraft.Crucible.PotionBases.Entities
         }
     }
 }
+
+#endif


### PR DESCRIPTION
Commented out most of Crucible.PotionBases since most of that was broken with 1.0. 
Fixed a few small issues with ingredients.
Added code to calculate element potentials for ingredients so the element filters work properly.