### PR TITLE
Updated crucible to work with Potion Craft v1.1.0

### DIFF
--- a/Crucible.GameAPI/CruciblePotionEffect.cs
+++ b/Crucible.GameAPI/CruciblePotionEffect.cs
@@ -322,9 +322,11 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             settings.lockedEffectIcon = defaultSettings.lockedEffectIcon;
             settings.effectSlotActiveSprite = defaultSettings.effectSlotActiveSprite;
             settings.effectSlotIdleSprite = defaultSettings.effectSlotIdleSprite;
-            settings.idleSepiaSettings = defaultSettings.idleSepiaSettings;
-            settings.unknownSepiaSettings = defaultSettings.unknownSepiaSettings;
-            settings.collectedSepiaSettings = defaultSettings.collectedSepiaSettings;
+
+            // TODO AF 12/13/23 Do these settings live somewhere else now or can they be deleted?
+            // settings.idleSepiaSettings = defaultSettings.idleSepiaSettings;
+            // settings.unknownSepiaSettings = defaultSettings.unknownSepiaSettings;
+            // settings.collectedSepiaSettings = defaultSettings.collectedSepiaSettings;
             settings.collectAnimationTime = defaultSettings.collectAnimationTime;
 
             EffectSettings.Add(effect, settings);

--- a/Crucible.GameAPI/GameHooks/IngredientsListResolveAtlasEvent.cs
+++ b/Crucible.GameAPI/GameHooks/IngredientsListResolveAtlasEvent.cs
@@ -156,16 +156,16 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI.GameHooks
             var found = false;
             foreach (var instruction in instructions)
             {
-                if (!found && instruction.opcode == OpCodes.Ldloc_S && instruction.operand is LocalBuilder localBuilder && localBuilder.LocalIndex == 5 && localBuilder.LocalType == typeof(PotionUsedComponent))
+                if (!found && instruction.opcode == OpCodes.Ldloc_S && instruction.operand is LocalBuilder localBuilder && localBuilder.LocalIndex == 6 && localBuilder.LocalType == typeof(PotionUsedComponent))
                 {
                     // We should now be right before the if statement checking if the current potion is in stock
                     found = true;
 
-                    yield return new CodeInstruction(OpCodes.Ldloc_S, 5); // currentPotion
+                    yield return new CodeInstruction(OpCodes.Ldloc_S, 6); // currentPotion
                     yield return new CodeInstruction(OpCodes.Call, getAtlasForUsedComponentMethod);
 
                     // Store the result into ingredientsAtlasName so it will be used in one of the two branching string constructions.
-                    yield return new CodeInstruction(OpCodes.Stloc_0);
+                    yield return new CodeInstruction(OpCodes.Stloc_1);
 
                     // Return the first part of the if-check and continue as normal.
                     yield return instruction;


### PR DESCRIPTION
- Removed the setting of some effect settings to defaults that appear to no longer be needed.
  - This code is not currently possible to hit since the effects module has not been updated with recent versions of Potion Craft.
- Updated the transpile method which modifies the `RecipeBookLeftPageContent.UpdateIngredientsList()` to point to the correct variable index since a new variable was added to the top of the method which incremented all later variable indexes.