### PR TITLE
Fixed potion sticker saving issue

### DIFF
--- a/Crucible.GameAPI/CruciblePotionSticker.cs
+++ b/Crucible.GameAPI/CruciblePotionSticker.cs
@@ -93,6 +93,7 @@ namespace RoboPhredDev.PotionCraft.Crucible.GameAPI
             }
 
             var sticker = ScriptableObject.CreateInstance<Sticker>();
+            sticker.name = id;
 
             var blankSprite = SpriteUtilities.CreateBlankSprite(1, 1, Color.clear);
             sticker.backgroundSprite = blankSprite;


### PR DESCRIPTION
Fixed issue where potion stickers would not be saved in the recipe book. This bug was due to the fact we were never actually saving the id to the sticker .name field even though surrounding code assumed the id would be used as the name.